### PR TITLE
Add support for token-secured Nightscout instances

### DIFF
--- a/NightscoutCounter/Configuration/PluginConfig.cs
+++ b/NightscoutCounter/Configuration/PluginConfig.cs
@@ -14,6 +14,8 @@ namespace NightscoutCounter.Configuration
 
         public virtual string NightscoutSiteURL { get; set; } = "https://example.herokuapp.com";
 
+        public virtual string NightscoutSiteToken { get; set; } = "";
+
         public virtual string DisplayType { get; set; } = "mg/dL (US)";
         public virtual bool ArrowsEnabled { get; set; } = true;
 

--- a/NightscoutCounter/NightscoutCounter.csproj
+++ b/NightscoutCounter/NightscoutCounter.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>NightscoutCounter</RootNamespace>
     <AssemblyName>NightscoutCounter</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <DebugType>portable</DebugType>
     <BeatSaberDir>C:\Program Files (x86)\Steam\steamapps\common\Beat Saber</BeatSaberDir>
@@ -18,6 +18,7 @@
     <ReferencePath>$(SolutionDir)Refs</ReferencePath>
     <AppOutputBase>$(MSBuildProjectDirectory)\</AppOutputBase>
     <PathMap>$(AppOutputBase)=X:\$(AssemblyName)\</PathMap>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/NightscoutCounter/UI/NightscoutSettingsHandler.cs
+++ b/NightscoutCounter/UI/NightscoutSettingsHandler.cs
@@ -21,6 +21,13 @@ namespace NightscoutCounter.UI
             }
         }
 
+        [UIValue("site-token")]
+        public string nightscoutToken
+        {
+            get => PluginConfig.Instance.NightscoutSiteToken;
+            set => PluginConfig.Instance.NightscoutSiteToken = value;
+        }
+
         [UIValue("display-options")]
         private List<object> displayOptions = new object[] { "mg/dL (US)", "mmol/L (Other)"}.ToList();
 

--- a/NightscoutCounter/UI/Views/NightscoutSettings.bsml
+++ b/NightscoutCounter/UI/Views/NightscoutSettings.bsml
@@ -1,5 +1,6 @@
 ﻿<vertical xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance' xsi:schemaLocation='https://monkeymanboy.github.io/BSML-Docs/ https://raw.githubusercontent.com/monkeymanboy/BSML-Docs/gh-pages/BSMLSchema.xsd' spacing='1' horizontal-fit='PreferredSize' vertical-fit='PreferredSize'>
   <string-setting text='Nightscout Site URL' value='site-url' apply-on-change='true'></string-setting>
+  <string-setting text='Nightscout Site Token' value='site-token' apply-on-change='true'></string-setting>
   <list-setting text='Display Type' value='display-choice' choices='display-options' apply-on-change='true'/>
   <checkbox-setting text='Show Direction' value='arrows-enabled' apply-on-change='true'></checkbox-setting>
   <slider-setting text="High Glucose Threshold" min='120' max='300' increment='5' value='high-threshold' integer-only='true' apply-on-change='true'></slider-setting>

--- a/NightscoutCounter/Utilities/NightscoutDataService.cs
+++ b/NightscoutCounter/Utilities/NightscoutDataService.cs
@@ -75,7 +75,14 @@ namespace NightscoutCounter.Utilities
             if (siteURL.Substring(0, 7) == "http://") siteURL = "https://" + siteURL.Substring(7);
             if (siteURL.Substring(0, 8) != "https://") siteURL = "https://" + siteURL;
 
-            string responseString = await client.GetStringAsync(siteURL + "api/v1/entries.json?count=1");
+            string requestURL = siteURL + "api/v1/entries.json?count=1";
+
+            if (PluginConfig.Instance.NightscoutSiteToken.Length != 0)
+            {
+                requestURL = requestURL + "&token=" + PluginConfig.Instance.NightscoutSiteToken;
+            }
+
+            string responseString = await client.GetStringAsync(requestURL);
             NightscoutData nightscoutData = JsonConvert.DeserializeObject<NightscoutData>(responseString.Substring(1, responseString.Length - 2));
             nightscoutData.directionSymbol = ArrowValues(nightscoutData.direction);
             nightscoutData.color = ColorFromBG(nightscoutData.sgv);


### PR DESCRIPTION
This PR adds a token setting in the counter's config menu, which will append `&token=[the access token]` to the NS request URL and allow the plugin to read data from secured NS instances.

I also had to change the framework version from v4.7.2 to v4.8 because [Counters+ switched to it back in September 2021](https://github.com/Caeden117/CountersPlus/commit/1839af3ae5e76ff8fbb79266503fa7d42cfdc356#diff-e03bc7b03eaed29a585e9fefab9ef39915152a0aac2229d3d7cb43eb41fe2a19) and I couldn't compile on 4.7.2 with Counters+ being on 4.8. Bumping the framework version didn't seem to break anything from my observations.